### PR TITLE
Fix minor bugs and add guardrails to prevent reverting txns

### DIFF
--- a/features/manage-position/Create.tsx
+++ b/features/manage-position/Create.tsx
@@ -180,6 +180,7 @@ const Create = () => {
           type="number"
           label={`Collateral (${collSymbol})`}
           placeholder="1234"
+          inputProps={{ min: "0" }}
           value={collateral}
           error={balanceTooLow}
           helperText={balanceTooLow ? "Balance too low" : null}
@@ -193,6 +194,7 @@ const Create = () => {
           type="number"
           label={`Tokens (${tokenSymbol})`}
           placeholder="1234"
+          inputProps={{ min: "0" }}
           value={tokens}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             setTokens(e.target.value)

--- a/features/manage-position/Create.tsx
+++ b/features/manage-position/Create.tsx
@@ -30,6 +30,7 @@ const Create = () => {
     decimals: collDec,
     allowance: collAllowance,
     setMaxAllowance,
+    balance
   } = Collateral.useContainer();
   const { symbol: tokenSymbol, decimals: tokenDec } = Token.useContainer();
   const { gcr } = Totals.useContainer();
@@ -50,6 +51,7 @@ const Create = () => {
     collReq && collDec
       ? `${parseFloat(fromWei(collReq, collDec)) * 100}%`
       : "N/A";
+  const balanceTooLow = (balance || 0) < (Number(collateral) || 0);
 
   const needAllowance = () => {
     if (collAllowance === null || collateral === null) return true;
@@ -179,6 +181,8 @@ const Create = () => {
           label={`Collateral (${collSymbol})`}
           placeholder="1234"
           value={collateral}
+          error={balanceTooLow}
+          helperText={balanceTooLow ? "Balance too low" : null}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             setCollateral(e.target.value)
           }
@@ -205,7 +209,7 @@ const Create = () => {
             Approve
           </Button>
         )}
-        {tokens && collateral && gcr && !needAllowance() && computedCR > gcr ? (
+        {tokens && collateral && gcr && !needAllowance() && computedCR > gcr && !balanceTooLow ? (
           <Button
             variant="contained"
             onClick={handleCreateClick}

--- a/features/manage-position/Create.tsx
+++ b/features/manage-position/Create.tsx
@@ -36,6 +36,7 @@ const Create = () => {
   const {
     collateral: posCollateral,
     tokens: posTokens,
+    pendingWithdraw
   } = Position.useContainer();
 
   const [collateral, setCollateral] = useState<string>("");
@@ -119,6 +120,19 @@ const Create = () => {
 
   const computedCR = computeCR() || 0;
 
+  if (pendingWithdraw === null || pendingWithdraw === "Yes") {
+    return (
+        <Container>
+          <Box py={2}>
+            <Typography>
+              <i>You need to cancel or execute your pending withdrawal request before creating additional tokens.</i>
+            </Typography>
+          </Box>
+        </Container>
+    );
+  }
+
+  // User has no pending withdrawal requests so they can create tokens.
   return (
     <Container>
       <Box py={2}>

--- a/features/manage-position/Deposit.tsx
+++ b/features/manage-position/Deposit.tsx
@@ -13,13 +13,15 @@ const Container = styled(Box)`
 
 const Deposit = () => {
   const { contract: emp } = EmpContract.useContainer();
-  const { symbol: collSymbol } = Collateral.useContainer();
+  const { symbol: collSymbol, balance } = Collateral.useContainer();
   const { tokens, collateral, pendingWithdraw } = Position.useContainer();
 
   const [collateralToDeposit, setCollateralToDeposit] = useState<string>("");
   const [hash, setHash] = useState<string | null>(null);
   const [success, setSuccess] = useState<boolean | null>(null);
   const [error, setError] = useState<Error | null>(null);
+
+  const balanceTooLow = (balance || 0) < (Number(collateralToDeposit) || 0);
 
   const depositCollateral = async () => {
     if (collateralToDeposit && emp) {
@@ -95,6 +97,8 @@ const Deposit = () => {
           inputProps={{ min: "0" }}
           label={`Collateral (${collSymbol})`}
           placeholder="1234"
+          error={balanceTooLow}
+          helperText={balanceTooLow ? `${collSymbol} balance too low`: null}
           value={collateralToDeposit}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             setCollateralToDeposit(e.target.value)
@@ -103,7 +107,7 @@ const Deposit = () => {
       </Box>
 
       <Box py={2}>
-        {collateralToDeposit && collateralToDeposit != "0" ? (
+        {collateralToDeposit && collateralToDeposit != "0" && !balanceTooLow ? (
           <Button
             variant="contained"
             onClick={handleDepositClick}

--- a/features/manage-position/Deposit.tsx
+++ b/features/manage-position/Deposit.tsx
@@ -14,7 +14,7 @@ const Container = styled(Box)`
 const Deposit = () => {
   const { contract: emp } = EmpContract.useContainer();
   const { symbol: collSymbol } = Collateral.useContainer();
-  const { tokens, collateral } = Position.useContainer();
+  const { tokens, collateral, pendingWithdraw } = Position.useContainer();
 
   const [collateralToDeposit, setCollateralToDeposit] = useState<string>("");
   const [hash, setHash] = useState<string | null>(null);
@@ -67,7 +67,19 @@ const Deposit = () => {
     );
   }
 
-  // User has a position so can deposit more collateral.
+  if (pendingWithdraw === null || pendingWithdraw === "Yes") {
+    return (
+        <Container>
+          <Box py={2}>
+            <Typography>
+              <i>You need to cancel or execute your pending withdrawal request before depositing additional collateral.</i>
+            </Typography>
+          </Box>
+        </Container>
+    );
+  }
+
+  // User has a position and no pending withdrawal requests so can deposit more collateral.
   return (
     <Container>
       <Box pt={4} pb={2}>

--- a/features/manage-position/Deposit.tsx
+++ b/features/manage-position/Deposit.tsx
@@ -51,7 +51,7 @@ const Deposit = () => {
 
   const resultingCR =
     collateral && collateralToDeposit && tokens
-      ? collateral + parseFloat(collateralToDeposit) / tokens
+      ? (collateral + parseFloat(collateralToDeposit)) / tokens
       : startingCR;
 
   // User does not have a position yet.

--- a/features/manage-position/Redeem.tsx
+++ b/features/manage-position/Redeem.tsx
@@ -101,6 +101,7 @@ const Redeem = () => {
           label={`Redeeem (${syntheticSymbol})`}
           placeholder="1234"
           error={!isEmpty && !canSendTxn}
+          helperText={!isEmpty && !canSendTxn ? `Input must be between 0 and ${borrowedTokens}` : null}
           value={tokensToRedeem}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             setTokensToRedeem(e.target.value)

--- a/features/manage-position/Redeem.tsx
+++ b/features/manage-position/Redeem.tsx
@@ -101,6 +101,7 @@ const Redeem = () => {
           type="number"
           label={`Redeeem (${syntheticSymbol})`}
           placeholder="1234"
+          inputProps={{ min: "0" }}
           error={!isEmpty && !canSendTxn}
           helperText={!isEmpty && !canSendTxn ? `Input must be between 0 and ${maxRedeem}` : null}
           value={tokensToRedeem}

--- a/features/manage-position/Redeem.tsx
+++ b/features/manage-position/Redeem.tsx
@@ -16,7 +16,7 @@ const Redeem = () => {
   const { contract: emp } = EmpContract.useContainer();
   const { symbol: collSymbol } = Collateral.useContainer();
   const { tokens: borrowedTokens, collateral, pendingWithdraw } = Position.useContainer();
-  const { symbol: syntheticSymbol, allowance: syntheticAllowance, setMaxAllowance } = Token.useContainer();
+  const { symbol: syntheticSymbol, allowance: syntheticAllowance, setMaxAllowance, balance: syntheticBalance } = Token.useContainer();
 
   const [tokensToRedeem, setTokensToRedeem] = useState<string>("");
   const [hash, setHash] = useState<string | null>(null);
@@ -24,8 +24,9 @@ const Redeem = () => {
   const [error, setError] = useState<Error | null>(null);
 
   const tokensToRedeemFloat = isNaN(parseFloat(tokensToRedeem)) ? 0 : parseFloat(tokensToRedeem);
+  const maxRedeem = Math.min((syntheticBalance || 0), (borrowedTokens || 0));
   const isEmpty = tokensToRedeem === "";
-  const canSendTxn = !isNaN(parseFloat(tokensToRedeem)) && tokensToRedeemFloat >= 0 && tokensToRedeemFloat <= (borrowedTokens || 0);
+  const canSendTxn = !isNaN(parseFloat(tokensToRedeem)) && tokensToRedeemFloat >= 0 && tokensToRedeemFloat <= (maxRedeem);
 
   const needAllowance = () => {
     if (syntheticAllowance === null || tokensToRedeem === null) return true;
@@ -101,7 +102,7 @@ const Redeem = () => {
           label={`Redeeem (${syntheticSymbol})`}
           placeholder="1234"
           error={!isEmpty && !canSendTxn}
-          helperText={!isEmpty && !canSendTxn ? `Input must be between 0 and ${borrowedTokens}` : null}
+          helperText={!isEmpty && !canSendTxn ? `Input must be between 0 and ${maxRedeem}` : null}
           value={tokensToRedeem}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             setTokensToRedeem(e.target.value)

--- a/features/manage-position/Redeem.tsx
+++ b/features/manage-position/Redeem.tsx
@@ -15,7 +15,7 @@ const Container = styled(Box)`
 const Redeem = () => {
   const { contract: emp } = EmpContract.useContainer();
   const { symbol: collSymbol } = Collateral.useContainer();
-  const { tokens: borrowedTokens, collateral } = Position.useContainer();
+  const { tokens: borrowedTokens, collateral, pendingWithdraw } = Position.useContainer();
   const { symbol: syntheticSymbol, allowance: syntheticAllowance, setMaxAllowance } = Token.useContainer();
 
   const [tokensToRedeem, setTokensToRedeem] = useState<string>("");
@@ -72,7 +72,19 @@ const Redeem = () => {
     );
   }
 
-  // User has a position so can deposit more collateral.
+  if (pendingWithdraw === null || pendingWithdraw === "Yes") {
+    return (
+        <Container>
+          <Box py={2}>
+            <Typography>
+              <i>You need to cancel or execute your pending withdrawal request before redeeming tokens.</i>
+            </Typography>
+          </Box>
+        </Container>
+    );
+  }
+
+  // User has a position and no withdraw requests, so they can redeem tokens.
   return (
     <Container>
       <Box pt={4} pb={2}>

--- a/features/manage-position/Withdraw.tsx
+++ b/features/manage-position/Withdraw.tsx
@@ -125,7 +125,7 @@ const Deposit = () => {
 
   const resultingCR =
     collateral && collateralToWithdraw && tokens
-      ? collateral - parseFloat(collateralToWithdraw) / tokens
+      ? (collateral - parseFloat(collateralToWithdraw)) / tokens
       : startingCR;
 
   const resultingCRBelowGCR = resultingCR && gcr ? resultingCR < gcr : null;
@@ -143,11 +143,11 @@ const Deposit = () => {
     : null;
 
   const pendingWithdrawTimeString = pendingWithdrawTimeRemaining
-    ? Math.floor(pendingWithdrawTimeRemaining / 3600) +
+    ? Math.max(0, Math.floor(pendingWithdrawTimeRemaining / 3600)) +
       ":" +
-      Math.floor((pendingWithdrawTimeRemaining % 3600) / 60) +
+      Math.max(0, Math.floor((pendingWithdrawTimeRemaining % 3600) / 60)) +
       ":" +
-      ((pendingWithdrawTimeRemaining % 3600) % 60)
+      Math.max(0, ((pendingWithdrawTimeRemaining % 3600) % 60))
     : null;
   // User does not have a position yet.
   if (collateral === null || collateral.toString() === "0") {

--- a/features/manage-position/Withdraw.tsx
+++ b/features/manage-position/Withdraw.tsx
@@ -135,7 +135,7 @@ const Deposit = () => {
 
   const pendingWithdrawTimeRemaining =
     collateral && withdrawPassTime && pendingWithdraw === "Yes"
-      ? withdrawPassTime - Math.floor(Date.now() / 1000)
+      ? withdrawPassTime - Math.floor(Date.now() / 1000) - 7200
       : null;
 
   const pastWithdrawTimeStamp = pendingWithdrawTimeRemaining


### PR DESCRIPTION
Fixes errors in computing the collateralization ratio in Deposit and Withdraw.

Fixes weirdness in displaying a past-expiry time for a withdraw request.

Blocks off other pages when there's a pending withdrawal request (because all other txns will fail).

Adds collateral input validation based on available balance for Create and Deposit.

Adds input validation for cases where the user doesn't have enough synthetic balance to Redeem.