### PR TITLE
Remove gas limit

### DIFF
--- a/features/manage-position/Create.tsx
+++ b/features/manage-position/Create.tsx
@@ -67,9 +67,7 @@ const Create = () => {
       const collateralWei = ethers.utils.parseUnits(collateral);
       const tokensWei = ethers.utils.parseUnits(tokens);
       try {
-        const tx = await emp.create([collateralWei], [tokensWei], {
-          gasLimit: 7000000,
-        });
+        const tx = await emp.create([collateralWei], [tokensWei]);
         setHash(tx.hash as string);
         await tx.wait();
         setSuccess(true);

--- a/features/manage-position/Deposit.tsx
+++ b/features/manage-position/Deposit.tsx
@@ -32,9 +32,7 @@ const Deposit = () => {
         collateralToDeposit
       );
       try {
-        const tx = await emp.deposit([collateralToDepositWei], {
-          gasLimit: 7000000,
-        });
+        const tx = await emp.deposit([collateralToDepositWei]);
         setHash(tx.hash as string);
         await tx.wait();
         setSuccess(true);

--- a/features/manage-position/Redeem.tsx
+++ b/features/manage-position/Redeem.tsx
@@ -43,9 +43,7 @@ const Redeem = () => {
         tokensToRedeem
       );
       try {
-        const tx = await emp.redeem([tokensToRedeemWei], {
-          gasLimit: 7000000,
-        });
+        const tx = await emp.redeem([tokensToRedeemWei]);
         setHash(tx.hash as string);
         await tx.wait();
         setSuccess(true);

--- a/features/manage-position/Withdraw.tsx
+++ b/features/manage-position/Withdraw.tsx
@@ -49,15 +49,11 @@ const Deposit = () => {
       );
       try {
         if (resultingCRBelowGCR) {
-          const tx = await emp.requestWithdrawal([collateralToWithdrawWei], {
-            gasLimit: 7000000,
-          });
+          const tx = await emp.requestWithdrawal([collateralToWithdrawWei]);
           setHash(tx.hash as string);
           await tx.wait();
         } else if (!resultingCRBelowGCR) {
-          const tx = await emp.withdraw([collateralToWithdrawWei], {
-            gasLimit: 7000000,
-          });
+          const tx = await emp.withdraw([collateralToWithdrawWei]);
           setHash(tx.hash as string);
           await tx.wait();
         }
@@ -78,9 +74,7 @@ const Deposit = () => {
       setError(null);
 
       try {
-        const tx = await emp.withdrawPassedRequest({
-          gasLimit: 7000000,
-        });
+        const tx = await emp.withdrawPassedRequest();
         setHash(tx.hash as string);
         await tx.wait();
 
@@ -101,9 +95,7 @@ const Deposit = () => {
       setError(null);
 
       try {
-        const tx = await emp.cancelWithdrawal({
-          gasLimit: 7000000,
-        });
+        const tx = await emp.cancelWithdrawal();
         setHash(tx.hash as string);
         await tx.wait();
 


### PR DESCRIPTION
This will allow these transactions to estimate their own gas. With a gas limit of 7MM, most of these transactions would ask the user to send $20+ in gas for all of these transactions even though they would really only use a fraction of that.

I'm having trouble testing this in a mainnet fork, but I've done some light testing on mainnet to verify that Ethers correctly estimates gas when this parameter is left out. @adrianmcli, since you have a lot of experience with Ethers, could you verify that this should, indeed, work and give the user a reasonable gas limit?