### PR TITLE
Current GCR should have the same precision as user's expected CR

### DIFF
--- a/features/manage-position/Withdraw.tsx
+++ b/features/manage-position/Withdraw.tsx
@@ -289,7 +289,7 @@ const Deposit = () => {
       </Box>
 
       <Box py={2}>
-        <Typography>Current global CR: {gcr?.toFixed(2) || "N/A"}</Typography>
+        <Typography>Current global CR: {gcr || "N/A"}</Typography>
         <Typography>Current position CR: {startingCR || "N/A"}</Typography>
         <Typography>Resulting position CR: {resultingCR || "N/A"}</Typography>
         {collateralToWithdraw && collateralToWithdraw != "0" ? (


### PR DESCRIPTION
Otherwise, this can create an issue where it appears as if the user's CR is above the GCR, so a fast withdrawal is possible, but the UI doesn't allow you to do it.