### PR TITLE
make chain script use different config from frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "chain": "ts-node chain.ts"
+    "chain": "ts-node -O '{\"module\":\"commonjs\"}' chain.ts"
   },
   "dependencies": {
     "@material-ui/core": "^4.10.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "commonjs",
+    "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
Next.js requires Typescript compiler options of `"module": "esnext"`, while the `chain.ts` script requires `"module": "commonjs"`. To get around this, we explicitly run the `chain.ts` command with a compiler option to force `commonjs` modules.

References:
- https://github.com/TypeStrong/ts-node/issues/992
- https://github.com/vercel/next.js/issues/7361#issuecomment-494975798