### PR TITLE
Add new error message to Create if user has not selected an EMP

### DIFF
--- a/features/manage-position/Create.tsx
+++ b/features/manage-position/Create.tsx
@@ -129,6 +129,19 @@ const Create = () => {
 
   const etherscanUrl = useEtherscanUrl(hash);
 
+  // User has not selected an EMP yet. We can detect this by checking if any properties in `empState` are `null`.
+  if (collReq === null) {
+    return (
+      <Container>
+        <Box py={2}>
+          <Typography>
+            <i>Please first select an EMP from the dropdown above.</i>
+          </Typography>
+        </Box>
+      </Container>
+    );
+  }
+
   if (pendingWithdraw === null || pendingWithdraw === "Yes") {
     return (
         <Container>


### PR DESCRIPTION
Resolves #23 

Open question: Should we add this error message to Deposit/Redeem/Withdraw/Transfer as well? Currently they all display the error message whe `collateral === null` which is something to the effect of "you need a position to do this action".
Signed-off-by: Nick Pai <npai.nyc@gmail.com>